### PR TITLE
Dashboard Fixes #8 - fix: Correct local time display for all cities

### DIFF
--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -230,9 +230,9 @@ const Dashboard = () => {
                         'July', 'August', 'September', 'October', 'November', 'December'];
     
     const updateLocalTime = () => {
-      // Get current UTC time in milliseconds
+      // Get current UTC time in milliseconds (getTime() already returns UTC)
       const now = new Date();
-      const utcMillis = now.getTime() + (now.getTimezoneOffset() * 60000); // Convert to true UTC
+      const utcMillis = now.getTime();
       
       // Apply timezone offset (convert hours to milliseconds)
       const localMillis = utcMillis + (selectedCity.tz * 3600000);


### PR DESCRIPTION
## Description
Fixes incorrect local time display in the Sunrise & Sunset section. Times were offset by the user's local timezone due to double UTC conversion.

## Problem
The code was adding `getTimezoneOffset()` to `getTime()`, but `getTime()` already returns UTC milliseconds since epoch. This caused a double conversion:
- NYC showing 9 AM instead of 4 AM
- All cities showing incorrect times offset by user's local timezone

## Solution
Removed the unnecessary `getTimezoneOffset()` conversion:

**Before:**
```javascript
const utcMillis = now.getTime() + (now.getTimezoneOffset() * 60000);
````

**After:**
```javascript 
const utcMillis = now.getTime();

````

## Testing
[x] Verified NYC shows correct EDT time
[x] Verified Tokyo shows correct JST time
[x] Verified London shows correct GMT time
[x] Tested with multiple cities
[x] Confirmed real-time updates work correctly

## Changes
- Modified [updateLocalTime]) function in [Dashboard.tsx]
- Simplified UTC calculation
- Maintained timezone offset application logic

## Closes
Fixes #8 